### PR TITLE
Fix blank line in config_db.php

### DIFF
--- a/root/etc/e-smith/templates/etc/glpi/config_db.php/10base
+++ b/root/etc/e-smith/templates/etc/glpi/config_db.php/10base
@@ -15,6 +15,5 @@ $OUT .= qq(
  var \$dbdefault = 'glpi';
                 
  } 
-?>
-);
+?>);
 }


### PR DESCRIPTION
Images are not shown in browser because of a blank line after the php closing tag `?>` in `/etc/glpi/config_db.php`, see https://community.nethserver.org/t/glpi-error-displaying-jpg-documents/18616